### PR TITLE
feat: generate match_token api and join "match:lobby" socket using match_token

### DIFF
--- a/lib/hunger/application.ex
+++ b/lib/hunger/application.ex
@@ -24,7 +24,14 @@ defmodule Hunger.Application do
       %{
         id: Hunger.MatchSupervisor,
         start: {Hunger.MatchSupervisor, :start_link, [[]]}
-      }
+      },
+      {Hunger.Mm.GuestPool, []},
+      {Hunger.Mm.Lobby, []},
+      %{
+        id: Hunger.Mm.MatchMakerSupervisor,
+        start: {Hunger.Mm.MatchMakerSupervisor, :start_link, [[]]}
+      },
+      {Hunger.Mm.MatchMakerLeader, []}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/hunger/mm/guest_pool.ex
+++ b/lib/hunger/mm/guest_pool.ex
@@ -1,0 +1,56 @@
+defmodule Hunger.Mm.GuestPool do
+  use GenServer
+
+  @guests_table :guests_table
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(state) do
+    :ets.new(@guests_table, [:set, :public, :named_table])
+    g1 = %{id: "127.0.0.1-a", token: "mm_1", name: "a", public_ip: "127.0.0.1"}
+    g2 = %{id: "127.0.0.1-b", token: "mm_2", name: "b", public_ip: "127.0.0.1"}
+    :ets.insert(@guests_table, {g1.id, g1.token, g1})
+    :ets.insert(@guests_table, {g2.id, g2.token, g2})
+    {:ok, state}
+  end
+
+  def add_guest(name, public_ip) do
+    guest = generate_user(name, public_ip)
+    :ets.insert(@guests_table, {guest.id, guest.token, guest})
+    guest
+  end
+
+  defp generate_user(name, public_ip) do
+    guest_id = parse_user_id(name, public_ip)
+    guest_token = "mm_#{:crypto.strong_rand_bytes(12) |> Base.url_encode64()}"
+    %{id: guest_id, name: name, token: guest_token, public_ip: public_ip}
+  end
+
+  defp parse_user_id(name, public_ip) do
+    public_ip = public_ip |> Tuple.to_list() |> Enum.join(".")
+    "#{public_ip}-#{name}"
+  end
+
+  def find_guest_by_token(token) do
+    case :ets.match_object(@guests_table, {:_, token, :"$1"}) do
+      [] -> nil
+      [g | _] -> elem(g, 2)
+    end
+  end
+
+  def find_guest_by_id(guest_id) do
+    :ets.lookup(@guests_table, guest_id) |> List.first()
+  end
+
+  def remove_guest(guest_id) do
+    case :ets.lookup(@guests_table, guest_id) do
+      [] ->
+        {:error, "guest not found"}
+
+      [g | _] ->
+        :ets.delete(@guests_table, g)
+    end
+  end
+end

--- a/lib/hunger/mm/lobby.ex
+++ b/lib/hunger/mm/lobby.ex
@@ -1,0 +1,82 @@
+defmodule Hunger.Mm.Lobby do
+  use GenServer
+  alias Hunger.Mm.MatchMakerLeader
+
+  @capacity 2
+
+  def start_link(_) do
+    GenServer.start_link(
+      __MODULE__,
+      %{
+        users: %{},
+        processing: %{}
+      },
+      name: __MODULE__
+    )
+  end
+
+  def init(state) do
+    {:ok, state}
+  end
+
+  def add_user(user_id) do
+    GenServer.cast(__MODULE__, {:add_user, user_id})
+  end
+
+  def remove_user(user_id) do
+    GenServer.cast(__MODULE__, {:remove_user, user_id})
+  end
+
+  def handle_cast(
+        {:add_user, user_id},
+        %{users: users, processing: processing} = state
+      ) do
+    IO.inspect("Adding user #{user_id} to lobby")
+
+    case Map.has_key?(processing, user_id) do
+      true ->
+        IO.inspect("User #{user_id} is already in processing")
+        {:noreply, state}
+
+      false ->
+        new_user = %{id: user_id, joined_at: DateTime.utc_now()}
+        new_users = Map.put(users, user_id, new_user)
+
+        if Enum.count(users) + 1 < @capacity do
+          {:noreply, %{state | users: new_users}}
+        else
+          IO.inspect("Make a match")
+          updated_users = Map.values(users) ++ [new_user]
+          MatchMakerLeader.add_match_maker(updated_users)
+
+          updated_processing =
+            Enum.reduce(updated_users, processing, fn itm, acc ->
+              Map.put(acc, itm.id, itm)
+            end)
+
+          notify_message(updated_users, "init_match", updated_users)
+
+          {:noreply, %{state | users: %{}, processing: updated_processing}}
+        end
+    end
+  end
+
+  def notify_message(users, message, payload) when is_list(users) do
+    HungerWeb.Endpoint.broadcast("match:lobby", message, payload)
+  end
+
+  def handle_cast({:remove_user, user_id}, %{users: users, processing: processing} = state) do
+    IO.inspect("Removing user #{user_id} from lobby: #{Enum.count(users)}")
+
+    new_users =
+      if Map.has_key?(users, user_id) do
+        Map.delete(users, user_id)
+      else
+        users
+      end
+
+    # TODO: we should remove user in the processing
+
+    {:noreply, %{state | users: new_users, processing: processing}}
+  end
+end

--- a/lib/hunger/mm/match_maker.ex
+++ b/lib/hunger/mm/match_maker.ex
@@ -1,0 +1,72 @@
+defmodule Hunger.Mm.MatchMaker do
+  use GenServer, restart: :temporary
+
+  @timeout 30_000
+
+  def start_link(%{name: name, users: users}) do
+    GenServer.start_link(
+      __MODULE__,
+      %{
+        users: users,
+        state: :processing,
+        timeout_ref: nil
+      },
+      name: {:global, "mm:#{name}"}
+    )
+  end
+
+  def init(state) do
+    {:ok, state}
+  end
+
+  def create_match(users) do
+    GenServer.cast(__MODULE__, {:create_match, users})
+  end
+
+  def handle_cast({:create_match, users}, state) do
+    IO.inspect("Creating match with users #{inspect(users)}")
+
+    timeout_ref = Process.send_after(self(), :timeout, @timeout)
+    {:noreply, %{state | users: users, timeout_ref: timeout_ref}}
+  end
+
+  def handle_info(:timeout, %{users: users, state: :processing} = state) do
+    IO.inspect("Matchmaking timed out")
+    notify_users(users, %{state: :failed})
+    {:stop, :timeout, %{state | state: :failed}}
+  end
+
+  def handle_cast({:accept, user_id}, %{users: users, state: :processing} = state) do
+    IO.inspect("User #{user_id} accepted the match")
+
+    new_users =
+      for user = %{id: id, socket: socket, accepted: false} <- users, id != user_id, do: user
+
+    accepted_user = List.keyfind(users, :id, user_id)
+
+    if accepted_user do
+      updated_user = Map.put(accepted_user, :accepted, true)
+      new_users = new_users ++ [updated_user]
+    end
+
+    if Enum.all?(new_users, fn user -> user.accepted end) do
+      Process.cancel_timer(state.timeout_ref)
+      notify_users(new_users, %{state: :success})
+      {:stop, :normal, %{state | users: [], state: :success}}
+    else
+      {:noreply, %{state | users: new_users}}
+    end
+  end
+
+  def handle_cast({:decline, user_id}, %{state: :processing} = state) do
+    IO.inspect("User #{user_id} declined the match")
+    notify_users(state.users, %{state: :failed})
+    {:stop, :normal, %{state | users: [], state: :failed}}
+  end
+
+  defp notify_users(users, message) do
+    Enum.each(users, fn user ->
+      send(user.socket, message)
+    end)
+  end
+end

--- a/lib/hunger/mm/match_maker_dynamic_supervisor.ex
+++ b/lib/hunger/mm/match_maker_dynamic_supervisor.ex
@@ -1,0 +1,29 @@
+defmodule Hunger.Mm.MatchMakerSupervisor do
+  use DynamicSupervisor
+  alias Hunger.Mm.MatchMaker
+
+  def start_link(_opts \\ []) do
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(:ok) do
+    IO.inspect("start #{__MODULE__}")
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_match_maker(name, users) do
+    spec = %{id: MatchMaker, start: {MatchMaker, :start_link, [%{users: users, name: name}]}}
+
+    case DynamicSupervisor.start_child(__MODULE__, spec) do
+      {:ok, pid} ->
+        pid
+
+      {:error, {:already_started, pid}} ->
+        pid
+    end
+  end
+
+  def stop_match_maker(match_maker_pid) do
+    DynamicSupervisor.terminate_child(__MODULE__, match_maker_pid)
+  end
+end

--- a/lib/hunger/mm/match_maker_leader.ex
+++ b/lib/hunger/mm/match_maker_leader.ex
@@ -1,0 +1,46 @@
+defmodule Hunger.Mm.MatchMakerLeader do
+  use GenServer
+
+  alias Hunger.Mm.MatchMakerSupervisor
+
+  def start_link(_) do
+    GenServer.start_link(
+      __MODULE__,
+      %{
+        match_makers: %{}
+      },
+      name: __MODULE__
+    )
+  end
+
+  def add_match_maker(users) do
+    name = generate_name()
+    GenServer.call(__MODULE__, {:add_match_maker, name, users})
+    name
+  end
+
+  def remove_match_maker(name) do
+    GenServer.cast(__MODULE__, {:remove_match_maker, name})
+  end
+
+  def generate_name() do
+    :crypto.strong_rand_bytes(6) |> Base.url_encode64(padding: false)
+  end
+
+  def init(state) do
+    {:ok, state}
+  end
+
+  def handle_call({:add_match_maker, name, users}, _from, %{match_makers: match_makers} = state) do
+    match_pid = MatchMakerSupervisor.start_match_maker(name, users)
+
+    updated_match_makers = Map.put(match_makers, name, match_pid)
+
+    {:reply, :ok, %{state | match_makers: updated_match_makers}}
+  end
+
+  def handle_cast({:remove_match_maker, name}, %{match_makers: match_makers} = state) do
+    updated_match_makers = Map.delete(match_makers, name)
+    {:noreply, %{state | match_makers: updated_match_makers}}
+  end
+end

--- a/lib/hunger_web/channels/match_channel.ex
+++ b/lib/hunger_web/channels/match_channel.ex
@@ -1,0 +1,56 @@
+defmodule HungerWeb.MatchChannel do
+  use Phoenix.Channel
+  alias Hunger.Mm.Lobby
+
+  @impl true
+  def join("match:lobby", _message, socket) do
+    Lobby.add_user(socket.assigns.user_id)
+    {:ok, socket}
+  end
+
+  @impl true
+  def join("match:" <> _private_match_id, _params, _socket) do
+    {:error, %{reason: "unauthorized"}}
+  end
+
+  @impl true
+  def handle_in("accept", %{"group_id" => group_id}, socket) do
+    match_maker_pid = GenServer.whereis(MyApp.MatchMaker)
+    GenServer.call(match_maker_pid, {:accept, socket.assigns.user_id, group_id})
+    {:noreply, socket}
+  end
+
+  def handle_in("decline", %{"group_id" => group_id}, socket) do
+    match_maker_pid = GenServer.whereis(MyApp.MatchMaker)
+    GenServer.call(match_maker_pid, {:decline, socket.assigns.user_id, group_id})
+    {:noreply, socket}
+  end
+
+  def handle_info({:match_status, status}, socket) do
+    # socket = socket |> push_event("match_status", %{status: status})
+
+    # if status == :success do
+    #   socket = socket |> leave()
+    # end
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:match_group, group_id, users}, socket) do
+    if List.keymember?(users, socket.assigns.user_id, 0) do
+      socket =
+        socket
+        |> assign(:group_id, group_id)
+
+      # |> push_event("match_group", %{group_id: group_id, users: users})
+    end
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def terminate({:shutdown, _}, socket) do
+    Lobby.remove_user(socket.assigns.user_id)
+    {:stop, :shutdown, socket}
+  end
+end

--- a/lib/hunger_web/channels/match_socket.ex
+++ b/lib/hunger_web/channels/match_socket.ex
@@ -1,0 +1,85 @@
+defmodule HungerWeb.MatchSocket do
+  use Phoenix.Socket
+
+  channel "match:*", HungerWeb.MatchChannel
+
+  # A Socket handler
+  #
+  # It's possible to control the websocket connection and
+  # assign values that can be accessed by your channel topics.
+
+  ## Channels
+  # Uncomment the following line to define a "room:*" topic
+  # pointing to the `HungerWeb.RoomChannel`:
+  #
+  # channel "room:*", HungerWeb.RoomChannel
+  #
+  # To create a channel file, use the mix task:
+  #
+  #     mix phx.gen.channel Room
+  #
+  # See the [`Channels guide`](https://hexdocs.pm/phoenix/channels.html)
+  # for further details.
+
+  # Socket params are passed from the client and can
+  # be used to verify and authenticate a user. After
+  # verification, you can put default assigns into
+  # the socket that will be set for all channels, ie
+  #
+  #     {:ok, assign(socket, :user_id, verified_user_id)}
+  #
+  # To deny connection, return `:error`.
+  #
+  # See `Phoenix.Token` documentation for examples in
+  # performing token verification on connect.
+  @impl true
+  def connect(%{"match_token" => token}, socket, _connect_info)
+      when is_binary(token) do
+    case validate_token(token) do
+      {:ok, user} ->
+        updated_socket =
+          socket
+          |> assign(:user_id, user.id)
+          |> assign(:user_token, token)
+
+        {:ok, updated_socket}
+
+      {:error, reason} ->
+        {:error, %{reason: reason}}
+    end
+  end
+
+  def connect(params, _socket, _connect_info) do
+    IO.inspect(params)
+    {:error, %{reason: "Missing token"}}
+  end
+
+  # Socket id's are topics that allow you to identify all sockets for a given user:
+  #
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
+  #
+  # Would allow you to broadcast a "disconnect" event and terminate
+  # all active sockets and channels for a given user:
+  #
+  #     Elixir.HungerWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #
+  # Returning `nil` makes this socket anonymous.
+  @impl true
+  def id(socket), do: "user:#{socket.assigns.user_id}"
+
+  defp validate_token(token) do
+    case String.starts_with?(token, "mm_") do
+      true ->
+        case Hunger.Mm.GuestPool.find_guest_by_token(token) do
+          nil ->
+            {:error, "Invalid token"}
+
+          user ->
+            {:ok, user}
+        end
+
+      false ->
+        {:error, "Invalid token prefix"}
+    end
+  end
+end

--- a/lib/hunger_web/controllers/match_controller.ex
+++ b/lib/hunger_web/controllers/match_controller.ex
@@ -1,0 +1,16 @@
+defmodule HungerWeb.MatchController do
+  use HungerWeb, :controller
+  alias Hunger.Mm.GuestPool
+
+  action_fallback HungerWeb.FallbackController
+
+  def init(conn, %{"name" => name}) do
+    public_ip = conn.remote_ip
+
+    guest = GuestPool.add_guest(name, public_ip)
+
+    conn
+    |> put_status(:created)
+    |> render("pre-match.json", guest: guest)
+  end
+end

--- a/lib/hunger_web/endpoint.ex
+++ b/lib/hunger_web/endpoint.ex
@@ -12,6 +12,8 @@ defmodule HungerWeb.Endpoint do
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
+  socket "/ws", HungerWeb.MatchSocket, websocket: true, longpoll: false
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/lib/hunger_web/router.ex
+++ b/lib/hunger_web/router.ex
@@ -13,6 +13,8 @@ defmodule HungerWeb.Router do
       resources "/player", PlayerController, only: [:create]
       resources "/round", RoundController, only: [:create]
     end
+
+    post "/match-making", MatchController, :init
   end
 
   # Enables LiveDashboard only for development

--- a/lib/hunger_web/views/match_view.ex
+++ b/lib/hunger_web/views/match_view.ex
@@ -1,0 +1,11 @@
+defmodule HungerWeb.MatchView do
+  use HungerWeb, :view
+
+  def render("pre-match.json", %{guest: guest}) do
+    %{
+      id: guest.id,
+      name: guest.name,
+      token: guest.token
+    }
+  end
+end


### PR DESCRIPTION
## Changes
- Init the match_token by name
POST /api/match-making
body
```
{
        "name": "player_name"
}
```
response
```json
{
    "name": "ttt",
    "token": "mm_0RPpytnXOVWS_Aqx"
}
```

- websocket lib: https://www.npmjs.com/package/phoenix-channels
```js
const {Socket} = require('phoenix-channels')
let token = "mm_1"
let socket = new Socket("ws://localhost:4000/ws", {params: {match_token: token}})

socket.connect()

let channel = socket.channel("match:lobby", {
});


channel.join()
  .receive("ok", resp => {
      console.log("Joined successfully", resp)
      channel.isClosed
  })
  .receive("error", err => {
      console.log("Unable to join", err)
});

channel.on("init_match", (msg) => {
    console.log(msg)
});

let token2 = "mm_2"
let socket2 = new Socket("ws://localhost:4000/ws", {params: {match_token: token2}})

socket2.connect()

let channel2 = socket2.channel("match:lobby", {
});

channel2.join()
  .receive("ok", resp => {
      console.log("user 2 Joined successfully", resp)
  })
  .receive("error", err => {
      console.log("Unable to join", err)
});
```
